### PR TITLE
updates react-router to v1.0.0-rc1

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -1,7 +1,8 @@
 var React = require('react');
-var Router = require('react-router');
+var Router = require('react-router').Router;
 var routes = require('./config/routes');
 
-Router.run(routes, function(Root){
-  React.render(<Root />, document.getElementById('app'));
-});
+React.render(
+  <Router>{routes}</Router>, 
+  document.getElementById('app')
+);

--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -1,5 +1,4 @@
 var React = require('react');
-var ReactRouter = require('react-router');
 
 var Main = React.createClass({
   render: function(){

--- a/app/components/Main.js
+++ b/app/components/Main.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var RouteHandler = require('react-router').RouteHandler;
+var ReactRouter = require('react-router');
 
 var Main = React.createClass({
   render: function(){
@@ -11,7 +11,7 @@ var Main = React.createClass({
           </div>
         </nav>
         <div className="container">
-          <RouteHandler />
+          {this.props.children}
         </div>
       </div>
     )

--- a/app/config/routes.js
+++ b/app/config/routes.js
@@ -2,11 +2,11 @@ var React = require('react');
 var Main = require('../components/Main');
 var Home = require('../components/Home');
 var Router = require('react-router');
-var DefaultRoute = Router.DefaultRoute;
+var IndexRoute = Router.IndexRoute;
 var Route = Router.Route;
 
 module.exports = (
-  <Route name="app" path="/" handler={Main}>
-    <DefaultRoute handler={Home} />
+  <Route path="/" component={Main}>
+    <IndexRoute component={Home}/>
   </Route>
 );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/tylermcginnis/github-notetaker-egghead",
   "dependencies": {
     "react": "^0.13.3",
-    "react-router": "^0.13.3"
+    "react-router": "^1.0.0-rc1"
   },
   "devDependencies": {
     "babel-core": "^5.6.5",


### PR DESCRIPTION
This presented a number of issues with configuring react-router. Most of them
were straight forward enough, but the one that I spent the most time fixing was
that we no longer use a `<RouteHandler/>` in our Main component to populate the
sub-views of the application. Instead we pass `{this.props.children}` and the
mysterious, impossible to debug, jerk of an error about `type.toUpperCase` goes
away.
