### PR TITLE
fix public_repo conditional check in UserProfile

### DIFF
--- a/app/components/Github/UserProfile.js
+++ b/app/components/Github/UserProfile.js
@@ -9,8 +9,8 @@ const UserProfile = ({bio}) => {
       {bio.email && <li className="list-group-item">Email: {bio.email}</li>}
       {bio.location && <li className="list-group-item">Location: {bio.location}</li>}
       {bio.company && <li className="list-group-item">Company: {bio.company}</li>}
-      {bio.followers && <li className="list-group-item">Followers: {bio.followers}</li>}
-      {bio.following && <li className="list-group-item">Following: {bio.following}</li>}
+      {!!bio.followers && <li className="list-group-item">Followers: {bio.followers}</li>}
+      {!!bio.following && <li className="list-group-item">Following: {bio.following}</li>}
       {bio.following && <li className="list-group-item">Public Repos: {bio.public_repos}</li>}
       {bio.blog && <li className="list-group-item">Blog: <a href={bio.blog}> {bio.blog}</a></li>}
     </div>


### PR DESCRIPTION
If there are zero `followers` or `following`, the `0` is rendered without the `<li>`. Converting `0` to a boolean prevents `0` from being rendered.

Current
<img width="319" alt="screen shot 2015-12-17 at 12 54 44 pm" src="https://cloud.githubusercontent.com/assets/6968611/11881880/5795cea4-a4be-11e5-91eb-fb1358f75e45.png">

Fix
<img width="312" alt="screen shot 2015-12-17 at 1 02 17 pm" src="https://cloud.githubusercontent.com/assets/6968611/11881905/781c90fe-a4be-11e5-8c88-63e4fcba357a.png">
