### PR TITLE
Fix bindToState for re-base

### DIFF
--- a/app/components/Profile.js
+++ b/app/components/Profile.js
@@ -27,7 +27,7 @@ class Profile extends React.Component {
     base.removeBinding(this.ref);
   }
   init(username){
-    this.ref = base.bindToState(this.props.params.username, {
+    this.ref = base.bindToState(username, {
       context: this,
       asArrray: true,
       state: 'notes'


### PR DESCRIPTION
Shouldn't the argument be `username` instead of `this.props.params.username`? I don't know a lot about react, but changing username didn't update the notes. Using `username` fixed the problem but I don't know if that was the real problem.
