### PR TITLE
Fixed typo, extra r in asArray

### DIFF
--- a/app/components/Profile.js
+++ b/app/components/Profile.js
@@ -29,7 +29,7 @@ class Profile extends React.Component {
   init(username){
     this.ref = base.bindToState(username, {
       context: this,
-      asArrray: true,
+      asArray: true,
       state: 'notes'
     });
 


### PR DESCRIPTION
You had it as `asArrray` and it was causing the notes to be returned as an object which caused an error.
